### PR TITLE
FIX: pass kwargs to json.dump

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,10 +4,10 @@ codecov
 coverage
 flake8
 # TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
-git+git://github.com/awalter-bnl/ophyd@add-configure
+git+git://github.com/NSLS-II/ophyd@ophyd-for-suitcase-utils
 pytest >=3.9
 sphinx
-suitcase-utils[test_fixtures] >=0.1.0rc2
+suitcase-utils[test_fixtures] >=0.1.1
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib

--- a/suitcase/json_metadata/__init__.py
+++ b/suitcase/json_metadata/__init__.py
@@ -223,7 +223,7 @@ class Serializer(event_model.DocumentRouter):
         # open a json file for the metadata and add self._meta to it.
         f = self._manager.open('run_metadata',
                                f'{self._templated_file_prefix}meta.json', 'xt')
-        json.dump(self._meta, f)
+        json.dump(self._meta, f, **self._kwargs)
 
     def descriptor(self, doc):
         '''Add `descriptor` document information to the metadata dictionary.

--- a/suitcase/json_metadata/tests/tests.py
+++ b/suitcase/json_metadata/tests/tests.py
@@ -66,9 +66,7 @@ def test_export_with_kwargs(tmp_path, example_data, kwargs):
             content = f.read()
             actual = json.loads(content)
         n = 20
-        first_n_simbols = ('{\n' + \
-                            ' ' * kwargs['indent'] + \
-                            '"metadata": {\n' + \
-                            ' ' * kwargs['indent'])[:n]
+        first_n_simbols = ('{\n' + ' ' * kwargs['indent'] +
+                           '"metadata": {\n' + ' ' * kwargs['indent'])[:n]
         assert content[:n] == first_n_simbols
         assert actual == expected

--- a/suitcase/json_metadata/tests/tests.py
+++ b/suitcase/json_metadata/tests/tests.py
@@ -43,9 +43,9 @@ def test_export(tmp_path, example_data):
         assert actual == expected
 
 
-@pytest.mark.parametrize("kwargs", [{'sort_keys': True, 'indent': 4},
+@pytest.mark.parametrize("kwargs", [{'indent': 4},
                                     {'sort_keys': True, 'indent': 2,
-                                     'separators': (',', ':')}])
+                                     'separators': (',', ': ')}])
 def test_export_with_kwargs(tmp_path, example_data, kwargs):
     ''' runs a test using the plan that is passed through to it
 
@@ -63,5 +63,12 @@ def test_export_with_kwargs(tmp_path, example_data, kwargs):
 
     for filename in artifacts['run_metadata']:
         with open(filename) as f:
-            actual = json.load(f)
+            content = f.read()
+            actual = json.loads(content)
+        n = 20
+        first_n_simbols = ('{\n' + \
+                            ' ' * kwargs['indent'] + \
+                            '"metadata": {\n' + \
+                            ' ' * kwargs['indent'])[:n]
+        assert content[:n] == first_n_simbols
         assert actual == expected

--- a/suitcase/json_metadata/tests/tests.py
+++ b/suitcase/json_metadata/tests/tests.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 import event_model
 from .. import export
 import json
+import pytest
 
 
 def create_expected(collector):
@@ -35,6 +36,30 @@ def test_export(tmp_path, example_data):
     collector = example_data()
     expected = create_expected(collector)
     artifacts = export(collector, tmp_path, file_prefix='')
+
+    for filename in artifacts['run_metadata']:
+        with open(filename) as f:
+            actual = json.load(f)
+        assert actual == expected
+
+
+@pytest.mark.parametrize("kwargs", [{'sort_keys': True, 'indent': 4},
+                                    {'sort_keys': True, 'indent': 2,
+                                     'separators': (',', ':')}])
+def test_export_with_kwargs(tmp_path, example_data, kwargs):
+    ''' runs a test using the plan that is passed through to it
+
+    ..note::
+
+        Due to the `events_data` `pytest.fixture` this will run multiple tests
+        each with a range of detectors and a range of event_types. see
+        `suitcase.utils.conftest` for more info
+
+    '''
+
+    collector = example_data()
+    expected = create_expected(collector)
+    artifacts = export(collector, tmp_path, file_prefix='', **kwargs)
 
     for filename in artifacts['run_metadata']:
         with open(filename) as f:


### PR DESCRIPTION
This is to resolve the issue when the `**kwargs` weren't actually passed to the `json.dump`.

@mrakitin will work on adding a test for this case.